### PR TITLE
Bugfix for last point of line being dropped + other minor changes

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,6 +32,8 @@ function lineclip(points, bbox, result) {
                         result.push(part);
                         part = [];
                     }
+                } else if (i === len - 1) {
+                    part.push(b);
                 }
                 break;
 

--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ function lineclip(points, bbox, result) {
         codeA = lastCode;
     }
 
-    result.push(part);
+    if (part.length) result.push(part);
 
     return result;
 }

--- a/package.json
+++ b/package.json
@@ -9,12 +9,12 @@
     "tap": "^1.4.0"
   },
   "scripts": {
-    "test": "eslint index.js test.js && tap test.js",
+    "test": "tap test.js && eslint index.js test.js",
     "cov": "tap test.js --cov"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mapbox/linematch.git"
+    "url": "git+https://github.com/mapbox/lineclip.git"
   },
   "keywords": [
     "algorithm",
@@ -29,7 +29,7 @@
   "author": "Vladimir Agafonkin",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/mapbox/linematch/issues"
+    "url": "https://github.com/mapbox/lineclip/issues"
   },
-  "homepage": "https://github.com/mapbox/linematch#readme"
+  "homepage": "https://github.com/mapbox/lineclip#readme"
 }

--- a/test.js
+++ b/test.js
@@ -83,3 +83,13 @@ test('preserves line if no protrusions exist', function (t) {
 
     t.end();
 });
+
+test('clips without leaving empty parts', function (t) {
+    var result = clip([
+        [40, 40], [50, 50]],
+        [0, 0, 30, 30]);
+
+    t.same(result, []);
+
+    t.end();
+});

--- a/test.js
+++ b/test.js
@@ -70,4 +70,16 @@ test('clips floating point lines', function (t) {
     ]]);
 
     t.end();
-})
+});
+
+test('preserves line if no protrusions exist', function (t) {
+    var result = clip([
+        [1, 1], [2, 2], [3, 3]],
+        [0, 0, 30, 30]);
+
+    t.same(result, [
+        [[1, 1], [2, 2], [3, 3]]
+    ]);
+
+    t.end();
+});


### PR DESCRIPTION
Hey @mourner, awesome library (like usual). In using it, I encountered and patched up a few things:
- If the last two coordinates of a segment exist within the bounding box, lineclip erroneously omits the last coordinate. The simple test is a line that doesn't go outside the bounding box + a check that the result is the original line.
- If all coordinates are outside of the bounding box (or if the last two of a segment are), there will be an extra empty part added to the output.
- Made tap run before eslint because the previous order made `console.log`-style debugging not possible.