### PR TITLE
fix for non-crossing polygons

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,7 +75,6 @@ function polygonclip(points, bbox) {
             break; 
         }
         prevInside = !(bitCode(prev, bbox) & edge);
-        
         for (i = 0; i < points.length; i++) {
             p = points[i];
             inside = !(bitCode(p, bbox) & edge);

--- a/index.js
+++ b/index.js
@@ -71,8 +71,11 @@ function polygonclip(points, bbox) {
     for (edge = 1; edge <= 8; edge *= 2) {
         result = [];
         prev = points[points.length - 1];
+        if (!prev) { 
+            break; 
+        }
         prevInside = !(bitCode(prev, bbox) & edge);
-
+        
         for (i = 0; i < points.length; i++) {
             p = points[i];
             inside = !(bitCode(p, bbox) & edge);

--- a/index.js
+++ b/index.js
@@ -71,9 +71,7 @@ function polygonclip(points, bbox) {
     for (edge = 1; edge <= 8; edge *= 2) {
         result = [];
         prev = points[points.length - 1];
-        if (!prev) { 
-            break; 
-        }
+        if (!prev) break; 
         prevInside = !(bitCode(prev, bbox) & edge);
         for (i = 0; i < points.length; i++) {
             p = points[i];

--- a/test.js
+++ b/test.js
@@ -93,3 +93,13 @@ test('clips without leaving empty parts', function (t) {
 
     t.end();
 });
+
+test('still works when polygon never crosses bbox', function (t) {
+    var result = clip.polygon([
+        [3, 3], [5, 3], [5, 5], [3, 5], [3, 3]],
+        [0, 0, 2, 2]);
+
+    t.same(result, []);
+
+    t.end();
+});


### PR DESCRIPTION
Previously, lineclip would error if you asked it to clip a polygon not within the bbox.